### PR TITLE
Over-Stacked: Added More methods to HeaplessMap

### DIFF
--- a/lib/over-stacked/src/heapless_bits.rs
+++ b/lib/over-stacked/src/heapless_bits.rs
@@ -32,59 +32,59 @@ use crate::heapless_vector::{HeaplessVec, HeaplessVecErr};
 /// # Heapless Bits
 /// Bits aids in the control of bit level modification, this is often used to create
 /// allocators or other applications that require chunks of memory or chunks of a resource
-/// to be allocated. 
-/// 
+/// to be allocated.
+///
 /// # Example Useage
 /// ```rust
 /// use over_stacked::heapless_bits::HeaplessBits;
-/// 
+///
 /// fn main() {
 ///     let mut bit_map: HeaplessBits<10> = HeaplessBits::new();
-/// 
+///
 ///     bit_map.set_bit(10, true).unwrap();
-/// 
+///
 ///     assert_eq!(bit_map.get_bit(10).unwrap(), true);
-/// } 
+/// }
 /// ```
-/// 
+///
 /// # Stack Based Allocation
 /// Stack based allocation has limitations as does all allocation methods. However,
-/// stack based is often the least flexable. This is because the stack needs to be 
-/// a known size at compile time. This limits us to having to set the amount of 
-/// 'BYTES' we want to use for our allocations. 
-/// 
-/// This is often very useful in cases where a heap allocator isn't practical, 
-/// and the need to something on the stack is a perfect choice. 
-/// 
+/// stack based is often the least flexable. This is because the stack needs to be
+/// a known size at compile time. This limits us to having to set the amount of
+/// 'BYTES' we want to use for our allocations.
+///
+/// This is often very useful in cases where a heap allocator isn't practical,
+/// and the need to something on the stack is a perfect choice.
+///
 /// # Limitations
-/// * Since we are limited to a stack allocation enviroment, this type is very slow 
+/// * Since we are limited to a stack allocation enviroment, this type is very slow
 /// to pass by value. This type *contains* its entire buffer, so its not able to be
-/// easily transfered. 
-/// 
+/// easily transfered.
+///
 /// * This can not allocate more memory! Even if an allocator is available, this type
-/// will not allocate more memory. It is limited to the size at compile time. 
-/// 
+/// will not allocate more memory. It is limited to the size at compile time.
+///
 /// * This can cause problems on small stack devices, or large allocation volumes do to
-/// stack crashing. This is where you over-allocate your stack causing the stack to 
+/// stack crashing. This is where you over-allocate your stack causing the stack to
 /// overflow. This means that its up to the user to correctly setup the size, and
 /// understand how that size is going to affect thier stack.  
 pub struct HeaplessBits<const BYTES: usize> {
     /// ## `data`
     /// The byte array used to store the bits as flags.
-    /// 
+    ///
     /// ## Improvements
-    /// We could allocate a buffer of `u64`, or even `usize` 
+    /// We could allocate a buffer of `u64`, or even `usize`
     /// to increase speed, however, due to rust's const
     /// eval system we can not do math at compile time. This
     /// causes problems with the user when they want to allocate
     /// only 4 bytes, and we want to have a 8 byte value.  
-    data: HeaplessVec<u8, BYTES>
+    data: HeaplessVec<u8, BYTES>,
 }
 
 impl<const BYTES: usize> HeaplessBits<BYTES> {
     pub fn new() -> Self {
         Self {
-            data: HeaplessVec::new()
+            data: HeaplessVec::new(),
         }
     }
 
@@ -138,9 +138,11 @@ impl<const BYTES: usize> HeaplessBits<BYTES> {
     #[inline]
     pub fn get_bit(&self, index: usize) -> Result<bool, HeaplessVecErr> {
         let (data_offset, bit_offset) = Self::get_offsets(index);
-        Ok(Self::get_flag_from_byte(self.get_byte(data_offset)?, bit_offset))
+        Ok(Self::get_flag_from_byte(
+            self.get_byte(data_offset)?,
+            bit_offset,
+        ))
     }
-
 }
 
 impl<const BYTES: usize> Default for HeaplessBits<BYTES> {
@@ -189,27 +191,84 @@ mod test {
 
     #[test]
     fn test_set_flag_in_byte() {
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b00000000, 0, true), 0b00000001);
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b00000000, 1, true), 0b00000010);
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b00000000, 2, true), 0b00000100);
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b00000000, 3, true), 0b00001000);
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b00000000, 4, true), 0b00010000);
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b00000000, 5, true), 0b00100000);
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b00000000, 6, true), 0b01000000);
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b00000000, 7, true), 0b10000000);
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b00000000, 0, true),
+            0b00000001
+        );
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b00000000, 1, true),
+            0b00000010
+        );
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b00000000, 2, true),
+            0b00000100
+        );
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b00000000, 3, true),
+            0b00001000
+        );
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b00000000, 4, true),
+            0b00010000
+        );
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b00000000, 5, true),
+            0b00100000
+        );
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b00000000, 6, true),
+            0b01000000
+        );
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b00000000, 7, true),
+            0b10000000
+        );
 
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b11111111, 0, false), 0b11111110);
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b11111111, 1, false), 0b11111101);
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b11111111, 2, false), 0b11111011);
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b11111111, 3, false), 0b11110111);
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b11111111, 4, false), 0b11101111);
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b11111111, 5, false), 0b11011111);
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b11111111, 6, false), 0b10111111);
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b11111111, 7, false), 0b01111111);
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b11111111, 0, false),
+            0b11111110
+        );
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b11111111, 1, false),
+            0b11111101
+        );
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b11111111, 2, false),
+            0b11111011
+        );
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b11111111, 3, false),
+            0b11110111
+        );
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b11111111, 4, false),
+            0b11101111
+        );
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b11111111, 5, false),
+            0b11011111
+        );
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b11111111, 6, false),
+            0b10111111
+        );
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b11111111, 7, false),
+            0b01111111
+        );
 
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b11100101, 0, false), 0b11100100);
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b10101101, 6, false), 0b10101101);
-        assert_eq!(HeaplessBits::<0>::set_flag_in_byte(0b11111111, 0, true), 0b11111111);
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b11100101, 0, false),
+            0b11100100
+        );
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b10101101, 6, false),
+            0b10101101
+        );
+        assert_eq!(
+            HeaplessBits::<0>::set_flag_in_byte(0b11111111, 0, true),
+            0b11111111
+        );
     }
 
     #[test]

--- a/lib/over-stacked/src/heapless_map.rs
+++ b/lib/over-stacked/src/heapless_map.rs
@@ -24,17 +24,18 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 */
 
 use crate::heapless_vector::{HeaplessVec, HeaplessVecErr};
+use core::slice::Iter;
 
 pub struct HeaplessMap<KeyType: PartialEq, ValueType, const QTY: usize> {
     keys: HeaplessVec<KeyType, QTY>,
-    values: HeaplessVec<ValueType, QTY>
+    values: HeaplessVec<ValueType, QTY>,
 }
 
 impl<KeyType: PartialEq, ValueType, const QTY: usize> HeaplessMap<KeyType, ValueType, QTY> {
     pub fn new() -> Self {
         Self {
             keys: HeaplessVec::new(),
-            values: HeaplessVec::new()
+            values: HeaplessVec::new(),
         }
     }
 
@@ -49,11 +50,71 @@ impl<KeyType: PartialEq, ValueType, const QTY: usize> HeaplessMap<KeyType, Value
         self.keys.iter().any(|value| key == value)
     }
 
-    pub fn remove(&self, key: &KeyType) {
-        todo!()
+    pub fn remove(&mut self, key: &KeyType) {
+        let index = if let Some(idx) = self.keys.find_index_of(key) {
+            idx
+        } else {
+            return;
+        };
+
+        self.keys.remove(index);
+        self.values.remove(index);
     }
 
-    
+    pub fn get(&self, key: &KeyType) -> Option<&ValueType> {
+        let index = self.keys.find_index_of(key)?;
 
+        Some(self.values.get(index).unwrap())
+    }
 
+    pub fn get_mut(&mut self, key: &KeyType) -> Option<&mut ValueType> {
+        let index = self.keys.find_index_of(key)?;
+
+        Some(self.values.get_mut(index).unwrap())
+    }
+}
+
+#[cfg(test)]
+pub mod test {
+    use crate::heapless_map::HeaplessMap;
+    use crate::heapless_vector::HeaplessVecErr;
+
+    #[test]
+    fn test_adding_keys() {
+        let mut map: HeaplessMap<usize, &str, 4> = HeaplessMap::new();
+
+        map.insert(0, "zero").unwrap();
+        map.insert(1, "one").unwrap();
+        map.insert(2, "two").unwrap();
+
+        assert_eq!(map.get(&0), Some(&"zero"));
+        assert_eq!(map.get(&1), Some(&"one"));
+        assert_eq!(map.get(&2), Some(&"two"));
+    }
+
+    #[test]
+    fn test_string_keys() {
+        let mut map: HeaplessMap<&str, usize, 4> = HeaplessMap::new();
+
+        map.insert("one", 1).unwrap();
+        map.insert("two", 2).unwrap();
+        map.insert("three", 3).unwrap();
+
+        assert_eq!(map.get(&"three").unwrap(), &3);
+        assert_eq!(map.get(&"one").unwrap(), &1);
+        assert_eq!(map.get(&"zero"), None);
+        assert_eq!(map.get(&"two"), Some(&2));
+    }
+
+    #[test]
+    fn over_and_under_size_test() {
+        let mut map: HeaplessMap<usize, usize, 10> = HeaplessMap::new();
+
+        for i in 0..9 {
+            map.insert(i, i + 1).unwrap();
+        }
+
+        assert_eq!(map.insert(9, 10), Ok(()));
+        assert_eq!(map.insert(10, 11), Err(HeaplessVecErr::VectorFull));
+    }
 }

--- a/lib/over-stacked/src/lib.rs
+++ b/lib/over-stacked/src/lib.rs
@@ -26,7 +26,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #![no_std]
 #![feature(test)]
 
-pub mod heapless_string;
-pub mod heapless_vector;
 pub mod heapless_bits;
 pub mod heapless_map;
+pub mod heapless_string;
+pub mod heapless_vector;


### PR DESCRIPTION
Added `find_index_of` to `HeaplessVec` to allow `HeaplessMap` to function.

Finally fleshed out some tests for `HeaplessMap`, with more `HeaplessMap` functions. 